### PR TITLE
feat: add /skills interactive TUI slash command (v0.8.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coding-agent"
-version = "0.7.1"
+version = "0.8.2"
 description = "Self-hosted, model-agnostic AI coding agent"
 requires-python = ">=3.10"
 dependencies = [
@@ -21,7 +21,7 @@ dependencies = [
 dev = ["pytest>=9.0"]
 
 [project.scripts]
-coding-agent = "coding_agent.cli:main"
+coding-agent = "coding_agent.cli:cli"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/coding_agent/config.py
+++ b/src/coding_agent/config.py
@@ -11,6 +11,47 @@ DEFAULT_CONFIG_FILE = DEFAULT_CONFIG_DIR / "config.yaml"
 OLLAMA_DEFAULT_API_BASE = "http://localhost:11434"
 
 
+class SkillSetting(BaseModel):
+    """Individual skill configuration."""
+    name: str
+    description: str
+    enabled: bool = True
+
+
+class SkillsConfig(BaseModel):
+    """Skills configuration."""
+    skills: list[SkillSetting] = []
+
+    def __init__(self, **data):
+        if not data.get("skills"):
+            data["skills"] = DEFAULT_SKILLS.copy()
+        super().__init__(**data)
+
+    def get_enabled(self) -> list[str]:
+        """Return list of enabled skill names."""
+        return [s.name for s in self.skills if s.enabled]
+
+
+DEFAULT_SKILLS = [
+    SkillSetting(name="algorithmic-art", description="Creating algorithmic art using p5.js with seeded randomness and interactive parameter exploration. Use this when users request creating art using code, generative art, algorithmic art, flow fields, or particle systems. Create original algorithmic art rather than copying existing artists' work to avoid copyright violations.", enabled=True),
+    SkillSetting(name="brand-guidelines", description="Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.", enabled=True),
+    SkillSetting(name="canvas-design", description="Create beautiful visual art in .png and .pdf documents using design philosophy. You should use this skill when the user asks to create a poster, piece of art, design, or other static piece. Create original visual designs, never copying existing artists' work to avoid copyright violations.", enabled=True),
+    SkillSetting(name="doc-coauthoring", description="Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar structured content.", enabled=True),
+    SkillSetting(name="docx", description="Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files).", enabled=True),
+    SkillSetting(name="frontend-design", description="Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications.", enabled=True),
+    SkillSetting(name="internal-comms", description="A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use.", enabled=True),
+    SkillSetting(name="mcp-builder", description="Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools.", enabled=True),
+    SkillSetting(name="pdf", description="Use this skill whenever the user wants to do anything with PDF files.", enabled=True),
+    SkillSetting(name="pptx", description="Use this skill any time a .pptx file is involved in any way - as input, output, or both.", enabled=True),
+    SkillSetting(name="skill-creator", description="Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities.", enabled=True),
+    SkillSetting(name="slack-gif-creator", description="Knowledge and utilities for creating animated GIFs optimized for Slack.", enabled=True),
+    SkillSetting(name="theme-factory", description="Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc.", enabled=True),
+    SkillSetting(name="web-artifacts-builder", description="Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies.", enabled=True),
+    SkillSetting(name="webapp-testing", description="Toolkit for interacting with and testing local web applications using Playwright.", enabled=True),
+    SkillSetting(name="xlsx", description="Use this skill any time a spreadsheet file is the primary input or output.", enabled=True),
+]
+
+
 def is_ollama_model(model: str) -> bool:
     """Return True if the model string uses the Ollama provider prefix."""
     return model.startswith(("ollama/", "ollama_chat/"))
@@ -47,6 +88,9 @@ class AgentConfig(BaseModel):
 
     # Context management
     max_context_tokens: int = 128000
+
+    # Skills configuration
+    skills: SkillsConfig = SkillsConfig()
 
     @field_validator("api_base")
     @classmethod

--- a/src/coding_agent/skills.py
+++ b/src/coding_agent/skills.py
@@ -1,11 +1,48 @@
 """SKILL.md loader and parser for custom slash commands."""
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from coding_agent.project_instructions import find_git_root
 
 DEFAULT_CONFIG_DIR = Path.home() / ".coding-agent"
-GLOBAL_SKILL_FILE = DEFAULT_CONFIG_DIR / "SKILL.md"
+GLOBAL_SKILLS_DIR = DEFAULT_CONFIG_DIR / "skills"
+
+
+@dataclass
+class Skill:
+    """Represents a loaded skill with metadata and resources."""
+    name: str
+    description: str
+    instructions: str
+    scripts_path: Path | None = None
+    references_path: Path | None = None
+    assets_path: Path | None = None
+
+
+def parse_yaml_frontmatter(content: str) -> tuple[dict[str, str], str]:
+    """Parse YAML frontmatter from SKILL.md content.
+
+    Args:
+        content: Raw SKILL.md file content.
+
+    Returns:
+        Tuple of (frontmatter dict, remaining content after frontmatter).
+    """
+    frontmatter: dict[str, str] = {}
+    remaining_content = content
+
+    if content.startswith("---"):
+        parts = content.split("---", 2)
+        if len(parts) >= 3:
+            yaml_block = parts[1]
+            remaining_content = parts[2]
+            for line in yaml_block.strip().splitlines():
+                if ":" in line:
+                    key, value = line.split(":", 1)
+                    frontmatter[key.strip()] = value.strip()
+
+    return frontmatter, remaining_content.strip()
 
 
 def find_project_skill_file(start_path: Path | None = None) -> Path | None:
@@ -30,40 +67,62 @@ def find_project_skill_file(start_path: Path | None = None) -> Path | None:
     return None
 
 
-def parse_skills(content: str) -> dict[str, str]:
-    """Parse SKILL.md content into a mapping of skill name to instructions.
+def find_skill_folder(skill_file: Path) -> Path | None:
+    """Find the skill folder containing SKILL.md.
 
-    Skills are defined as level-2 markdown sections (## skill-name).
-    The text under each heading becomes the skill's prompt instructions.
-    Skill names are lowercased and spaces replaced with hyphens.
+    Args:
+        skill_file: Path to SKILL.md file.
+
+    Returns:
+        Path to the skill folder, or None if not in a skill folder.
+    """
+    parent = skill_file.parent
+    if parent.name == ".coding-agent":
+        return parent
+    if parent.name == "skills":
+        return parent
+    if (parent / "SKILL.md").resolve() == skill_file.resolve():
+        return parent
+    return None
+
+
+def parse_skills(content: str, skill_folder: Path | None = None) -> dict[str, Skill]:
+    """Parse SKILL.md content into a mapping of skill name to Skill objects.
+
+    Each skill folder contains one skill. The skill name comes from the folder name.
+    Content is treated as instructions, with special sections (## Instructions, ## Examples)
+    parsed as part of the instructions.
 
     Args:
         content: Raw SKILL.md file content.
+        skill_folder: Optional path to skill folder for scripts/references/assets.
 
     Returns:
-        Dict mapping skill names to their instruction content.
+        Dict mapping skill names to Skill objects.
     """
-    skills: dict[str, str] = {}
-    current_name: str | None = None
-    current_lines: list[str] = []
+    frontmatter, content = parse_yaml_frontmatter(content)
+    global_description = frontmatter.get("description", "")
 
-    for line in content.splitlines():
-        if line.startswith("## "):
-            if current_name is not None:
-                skills[current_name] = "\n".join(current_lines).strip()
-            current_name = line[3:].strip().lower().replace(" ", "-")
-            current_lines = []
-        elif current_name is not None:
-            current_lines.append(line)
+    skill_name = skill_folder.name if skill_folder else "unknown"
 
-    if current_name is not None:
-        skills[current_name] = "\n".join(current_lines).strip()
+    scripts_path = skill_folder / "scripts" if skill_folder else None
+    references_path = skill_folder / "references" if skill_folder else None
+    assets_path = skill_folder / "assets" if skill_folder else None
 
-    return skills
+    skill = Skill(
+        name=skill_name,
+        description=global_description,
+        instructions=content,
+        scripts_path=scripts_path if scripts_path and scripts_path.is_dir() else None,
+        references_path=references_path if references_path and references_path.is_dir() else None,
+        assets_path=assets_path if assets_path and assets_path.is_dir() else None,
+    )
+
+    return {skill_name: skill}
 
 
-def load_skills(start_path: Path | None = None) -> tuple[dict[str, str], list[str]]:
-    """Load skills from project SKILL.md and global SKILL.md.
+def load_skills(start_path: Path | None = None) -> tuple[dict[str, Skill], list[str]]:
+    """Load skills from project SKILL.md and global skills directory.
 
     Project skills take priority over global skills with the same name.
 
@@ -73,24 +132,27 @@ def load_skills(start_path: Path | None = None) -> tuple[dict[str, str], list[st
     Returns:
         Tuple of (skills dict, list of loaded file paths for logging).
     """
-    all_skills: dict[str, str] = {}
+    all_skills: dict[str, Skill] = {}
     loaded_files: list[str] = []
 
-    # Load global skills first (lower priority)
-    if GLOBAL_SKILL_FILE.is_file():
-        try:
-            content = GLOBAL_SKILL_FILE.read_text(encoding="utf-8")
-            all_skills.update(parse_skills(content))
-            loaded_files.append(str(GLOBAL_SKILL_FILE))
-        except OSError:
-            pass
+    if GLOBAL_SKILLS_DIR.is_dir():
+        for skill_folder in GLOBAL_SKILLS_DIR.iterdir():
+            if skill_folder.is_dir():
+                skill_file = skill_folder / "SKILL.md"
+                if skill_file.is_file():
+                    try:
+                        content = skill_file.read_text(encoding="utf-8")
+                        all_skills.update(parse_skills(content, skill_folder))
+                        loaded_files.append(str(skill_file))
+                    except OSError:
+                        pass
 
-    # Load project skills (higher priority — overrides global)
     project_skill_file = find_project_skill_file(start_path)
     if project_skill_file:
         try:
             content = project_skill_file.read_text(encoding="utf-8")
-            all_skills.update(parse_skills(content))
+            skill_folder = find_skill_folder(project_skill_file)
+            all_skills.update(parse_skills(content, skill_folder))
             loaded_files.append(str(project_skill_file))
         except OSError:
             pass


### PR DESCRIPTION
## Summary

- Adds `/skills` REPL command: a keyboard-driven two-phase checkbox TUI built with `prompt_toolkit.Application` (inline, non-full-screen)
- Phase 1: navigable skill list — `↑`/`↓` to move, `Space` to toggle, `Enter` to confirm, `Esc`/`Ctrl+C` to cancel
- Phase 2: save confirmation — `Enter` writes to `~/.coding-agent/config.yaml`, `Esc` returns to the list
- Refactors `Skill` class to carry `instructions` and `description` attributes; updates `register_skills` accordingly
- Fixes entry point in `pyproject.toml` (`cli:main` → `cli:cli`)
- Bumps version `0.7.1 → 0.8.2`

## Test plan

- [ ] Run `coding-agent` (sandbox venv), type `/skills` — TUI appears inline
- [ ] Navigate with `↑`/`↓`, toggle a skill with `Space`, confirm with `Enter` → confirmation screen
- [ ] Press `Enter` again → "Saved: N/M skills enabled" message
- [ ] Press `Esc` on phase 2 → returns to checkbox list
- [ ] Press `Esc` on phase 1 → "Cancelled." message, config file unchanged
- [ ] Restart `coding-agent` → skill state persists in `~/.coding-agent/config.yaml`
- [ ] Run `pytest tests/test_slash_commands.py` — 22 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)